### PR TITLE
Add new humidifier type to VS_HUMIDIFIERS_TYPES list

### DIFF
--- a/custom_components/vesync/const.py
+++ b/custom_components/vesync/const.py
@@ -30,7 +30,7 @@ VS_MODE_TURBO = "turbo"
 VS_TO_HA_ATTRIBUTES = {"humidity": "current_humidity"}
 
 VS_FAN_TYPES = ["VeSyncAirBypass", "VeSyncAir131", "VeSyncAirBaseV2"]
-VS_HUMIDIFIERS_TYPES = ["VeSyncHumid200300S", "VeSyncHumid200S", "VeSyncHumid1000S", "VeSyncSuperior6000S"]
+VS_HUMIDIFIERS_TYPES = ["VeSyncHumid200300S", "VeSyncHumid200S", "VeSyncHumid1000S", "VeSyncSuperior6000S", "VeSyncHumid200300S"]
 VS_AIRFRYER_TYPES = ["VeSyncAirFryer158"]
 
 


### PR DESCRIPTION
Extended the list of humidifier types supported by the extension by adding "VeSyncHumid200300S". This ensures new humidifier models are recognized and supported by HomeAssistant

(cherry picked from commit c8af219ed9298e434d533604b710d88a49c70373)